### PR TITLE
Fix Dependabot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-    "name": "@narehood/stitch-revitalized-for-roku",
+    "name": "@qskwood/stitch-revitalized-for-roku",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "@narehood/stitch-revitalized-for-roku",
+            "name": "@qskwood/stitch-revitalized-for-roku",
             "dependencies": {
                 "@npmcli/fs": "^4.0.0",
                 "@rokucommunity/bslib": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@narehood/stitch-revitalized-for-roku",
+    "name": "@qskwood/stitch-revitalized-for-roku",
     "scripts": {
         "build": "bsc --createPackage=false",
         "watch": "npm run build -- --watch",


### PR DESCRIPTION
Previously package.json referenced the old repo owner name. This updates it and package-lock.json
to instead refer to the fork name. Note package-lock.json has not been otherwise regenerated at this
time.